### PR TITLE
Use task UID as ID

### DIFF
--- a/app/helpers/msproj_imp_helper.rb
+++ b/app/helpers/msproj_imp_helper.rb
@@ -38,7 +38,7 @@ module MsprojImpHelper
 
   def xml_tasks tasks
       task = MsprojTask.new
-      task.task_id = tasks.elements['ID'].text.to_i if tasks.elements['ID']
+      task.task_id = tasks.elements['ID'].text.to_i if tasks.elements['UID']
       task.wbs = tasks.elements['WBS'].text if tasks.elements['WBS']
 #      task.outline_number = tasks.elements['OutlineNumber'].text
       task.outline_level = tasks.elements['OutlineLevel'].text.to_i if tasks.elements['OutlineLevel']


### PR DESCRIPTION
Use task UID as ID, as it preserved between changes.
